### PR TITLE
13 - move shx param to hash to avoid logging

### DIFF
--- a/public/shlink.html
+++ b/public/shlink.html
@@ -9,11 +9,8 @@
     <script>
 
 	  const ich = document.URL.indexOf("#shlink:/");
-	  
-	  const param = (ich === -1 ? ''
-		 : '?shx=' + encodeURIComponent(document.URL.substring(ich + 1)));
-	  
-	  window.location = '/' + param;
+	  const hash = (ich === -1 ? '' : document.URL.substring(ich));
+	  window.location = '/' + hash;
 
     </script>
   </body>

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -24,6 +24,11 @@ export function getConfig() {
   const overrides = new URLSearchParams(overrideSource);
   overrides.forEach( (value, key) => { cfg[key] = value; });
 
+  // lastly if we have a hash value, add it as "shx" ... this is
+  // incoming from shlink.htm which is acting as the viewer url for a SHL
+  const hash = document.location.hash;
+  if (hash && hash.startsWith("#")) cfg["shx"] = hash.substring(1);
+
   _cfg = cfg;
   return(_cfg);
 }


### PR DESCRIPTION
Josh pointed out that my use of a query string param in this exchange could get logged (with the obvious privacy implication) ... this just moves it to the hash ... please let me know if you see any issues. Thanks! ---S