### PR TITLE
Render immunization histories

### DIFF
--- a/src/Data.js
+++ b/src/Data.js
@@ -5,6 +5,7 @@ import * as res from './lib/resources.js';
 import ValidationInfo from './ValidationInfo.js';
 
 import Coverage from './Coverage.js';
+import ImmunizationHistory from './ImmunizationHistory.js'
 import PatientSummary from './PatientSummary.js';
 
 export default function Data({ shx }) {
@@ -91,6 +92,10 @@ export default function Data({ shx }) {
 
 	    case res.BTYPE_PS:
 		  elt = <PatientSummary organized={ organized } />;
+		  break;
+
+	    case res.BTYPE_IMMUNIZATION:
+		  elt = <ImmunizationHistory organized={ organized } />;
 		  break;
 
 		// >>> ADD MORE RENDERERS HERE <<<

--- a/src/ImmunizationHistory.js
+++ b/src/ImmunizationHistory.js
@@ -1,0 +1,138 @@
+import * as futil from "./lib/fhirUtil.js";
+
+import styles from "./ImmunizationHistory.module.css";
+import { getVaccineCodeMapping } from "./lib/vaccineCodes.js";
+import { useState, useEffect } from "react";
+
+function immunizationsByPatient(resources) {
+  const groups = resources.reduce((acc, resource) => {
+    if (resource.resourceType !== "Immunization") {
+      return acc;
+    }
+    const key = resource.patient.reference;
+    if (!acc[key]) {
+      acc[key] = [];
+    }
+    acc[key].push(resource);
+    return acc;
+  }, {});
+
+  return Object.values(groups);
+}
+
+function renderImmunizationGroup(
+  key,
+  immunizations,
+  organized,
+  vaccineCodeMappings
+) {
+  const renderPatient = () => {
+    return (
+      <tr key={key}>
+        <th>Patient</th>
+        <td>{futil.renderPerson(immunizations[0].patient, organized.byId)}</td>
+      </tr>
+    );
+  };
+
+  const renderCodings = (codings) => {
+    return (
+      <ul>
+        {codings.map((c, index) => (
+          <li key={index}>
+            {c.code} ({c.system})
+          </li>
+        ))}
+      </ul>
+    );
+  };
+  const renderName = (codings) => {
+    if (!vaccineCodeMappings) {
+      return;
+    }
+    const code = codings[0];
+    if (vaccineCodeMappings) {
+      if (code?.system.includes("cvx")) {
+        return vaccineCodeMappings.cvx[code.code].name;
+      } else if (code?.system.includes("cpt")) {
+        return vaccineCodeMappings.cpt[code.code].name;
+      }
+    }
+  };
+  const renderPerformers = (performers) => {
+    return (
+      <ul>
+        {performers.map((p, index) => (
+          <li key={index}>{p.actor.display}</li>
+        ))}
+      </ul>
+    );
+  };
+  const renderImmunization = (immunization, key) => {
+    return (
+      <tr key={key}>
+        <td>{immunization.occurrenceDateTime}</td>
+        <td>{renderName(immunization.vaccineCode.coding)}</td>
+        <td>{renderCodings(immunization.vaccineCode.coding)}</td>
+        <td>{renderPerformers(immunization.performer)}</td>
+        <td>{immunization.lotNumber}</td>
+        <td>{immunization.status}</td>
+      </tr>
+    );
+  };
+
+  const renderImmunizations = () => {
+    return immunizations
+      .sort((a, b) => a.occurrenceDateTime > b.occurrenceDateTime)
+      .map((i, index) => renderImmunization(i, index));
+  };
+
+  const renderImmunizationHeaders = () => {
+    return (
+      <tr>
+        <th>Date Administered</th>
+        <th>Name</th>
+        <th>Coding</th>
+        <th>Performer</th>
+        <th>Lot Number</th>
+        <th>Status</th>
+      </tr>
+    );
+  };
+
+  return (
+    <table className={styles.dataTable}>
+      <tbody>{renderPatient()}</tbody>
+      <tbody>{renderImmunizationHeaders()}</tbody>
+      <tbody>{renderImmunizations()}</tbody>
+    </table>
+  );
+}
+
+export default function ImmunizationHistory({ organized }) {
+  const [vaccineCodeMappings, setVaccineCodeMappings] = useState(null);
+  useEffect(() => {
+    const fetchVaccineCodes = async () => {
+      const codes = await getVaccineCodeMapping();
+      setVaccineCodeMappings(codes);
+    };
+
+    fetchVaccineCodes();
+  }, []);
+  const immunizationGroups = immunizationsByPatient(
+    Object.values(organized.all)
+  );
+  if (immunizationGroups.length === 0) {
+    return;
+  }
+  return (
+    <div className={styles.container}>
+      <h2>Immunizations</h2>
+      {immunizationGroups.map((ig, index) => (
+        <div key={index}>
+          {renderImmunizationGroup(index, ig, organized, vaccineCodeMappings)}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/ImmunizationHistory.module.css
+++ b/src/ImmunizationHistory.module.css
@@ -1,0 +1,29 @@
+.dataTable {
+	margin-top: 24px;
+	margin-bottom: 24px;
+	border-collapse: collapse;
+}
+
+.dataTable th, .dataTable td {
+	min-width: 100px;
+	text-align: left;
+	vertical-align: top;
+	border: 1px solid grey;
+	padding: 8px 8px 8px 8px;
+	font-size: smaller;
+}
+
+.innerTable {
+	border-collapse: collapse;
+}
+
+.innerTable td, .innerTable th {
+	text-align: left;
+	vertical-align: middle;
+	padding: 2px 8px 2px 2px;
+	font-size: 100%;
+	border-top: none;
+	border-left: none;
+	border-right: none;
+	border-bottom: 1px solid lightgray;
+}

--- a/src/lib/resources.js
+++ b/src/lib/resources.js
@@ -31,6 +31,7 @@ import { hasCode } from './fhirUtil.js';
 export const BTYPE_COVERAGE = "cov";
 export const BTYPE_PS = "ps";
 export const BTYPE_BUNDLE = "Bundle";
+export const BTYPE_IMMUNIZATION = "imm";
 export const BTYPE_EMPTY = "empty"; // degenerate
 // ... or a resource type
 
@@ -85,6 +86,7 @@ function labelFromType(btype) {
     case BTYPE_PS: return("Patient Summary");
     case BTYPE_EMPTY: return("Invalid Content");
     case BTYPE_BUNDLE: return("Health Information");
+    case BTYPE_IMMUNIZATION: return("Immunization History");
     default: return(btype);
   }
 }
@@ -110,6 +112,7 @@ function figureOutType(organized) {
   if (organized.all.length === 0) return(BTYPE_EMPTY);
   if (isPatientSummary(organized)) return(BTYPE_PS);
   if (isCoverage(organized)) return(BTYPE_COVERAGE);
+  if (isImmunizationHistory(organized)) return(BTYPE_IMMUNIZATION);
 
   if(organized.all.length === 1) return(organized.all[0].resourceType);
   return(BTYPE_BUNDLE);
@@ -124,4 +127,11 @@ function isCoverage(organized) {
   return(organized.countOfType("Coverage") > 0);
 }
 
-
+function isImmunizationHistory(organized) {
+  // Immunization histories are a combination of a patient and some number of immunizations for that patient.
+  return (
+    Object.keys(organized.byType).length === 2 &&
+    organized.countOfType("Immunization") > 0 &&
+    organized.countOfType("Patient") === 1
+  );
+}

--- a/src/lib/vaccineCodes.js
+++ b/src/lib/vaccineCodes.js
@@ -1,0 +1,14 @@
+var _vaccineCodeMapping = undefined;
+
+export async function getVaccineCodeMapping() {
+  if (_vaccineCodeMapping) return _vaccineCodeMapping;
+  try {
+    const response = await fetch(
+      "https://raw.githubusercontent.com/hellodocket/vaccine-code-mappings/main/vaccine-code-mapping.json"
+    );
+    _vaccineCodeMapping = await response.json();
+  } catch (error) {
+    console.error("There was a problem fetching vaccine codes", error);
+  }
+  return _vaccineCodeMapping;
+}


### PR DESCRIPTION
An initial attempt at rendering immunization histories. These histories are identified by a FHiR bundle containing multiple immunization resources.

Uses vaccine code mappings pulled from from
https://github.com/hellodocket/vaccine-code-mappings/ in order to identify vaccine names.

---


Sean and I had a conversation about how to retrieve coding names over email and discussed 

- building a  server-side API caching a bunch of vocabularies all in one place
- packing value sets (eg https://terminology.smarthealth.cards/ValueSet-immunization-all-cvx.json) into a library

Before pursuing these options however, the simplest thing I can do is export the JSON file Docket builds when scraping the CDC definitions: https://github.com/hellodocket/vaccine-code-mappings/. Compared to other code systems, the entire set is pretty small, so I think it's ok for every client to fetch the whole mapping file.

---

Example

- Note: I have to fix DOB on Docket's side to be a string JS Date will parse.
- 
![image](https://github.com/the-commons-project/shc-web-reader/assets/115377954/1f233c20-3a53-4b88-a361-8e030446a4a3)

