### PR TITLE
36 warn in ehr context when selected patient doesnt match scanned data

### DIFF
--- a/src/Data.js
+++ b/src/Data.js
@@ -5,6 +5,7 @@ import { verifySHX, SHX_STATUS_NEED_PASSCODE, SHX_STATUS_OK  } from './lib/SHX.j
 import { saveDivToFile, saveDivToFHIR } from './lib/saveDiv.js';
 import * as res from './lib/resources.js';
 import ValidationInfo from './ValidationInfo.js';
+import WrongPatientWarning from './WrongPatientWarning.js';
 
 import Coverage from './Coverage.js';
 import ImmunizationHistory from './ImmunizationHistory.js'
@@ -115,6 +116,7 @@ export default function Data({ shx }) {
 		{ renderBundleChooser() }
 		<div id="bundle-contents">
 		  <ValidationInfo bundle={bundle} />
+		  <WrongPatientWarning organized={organized} />
 		  { elt }
 		</div>
 		<div>

--- a/src/Data.js
+++ b/src/Data.js
@@ -88,7 +88,7 @@ export default function Data({ shx }) {
 
 	if (organized) {
 	  
-	  switch (organized.btype) {
+	  switch (organized.typeInfo.btype) {
 		
 	    case res.BTYPE_COVERAGE:
 		  elt = <Coverage organized={ organized } />;
@@ -135,8 +135,10 @@ export default function Data({ shx }) {
 					  shxResult.bundles &&
 					  shxResult.bundles[bundleIndex] &&
 					  shxResult.bundles[bundleIndex].organized &&
-					  shxResult.bundles[bundleIndex].organized.label
-					  ? shxResult.bundles[bundleIndex].organized.label
+					  shxResult.bundles[bundleIndex].organized.typeInfo &&
+					  shxResult.bundles[bundleIndex].organized.typeInfo.label
+					  
+					  ? shxResult.bundles[bundleIndex].organized.typeInfo.label
 					  : "Shared Information");
 
 	const div = document.getElementById("bundle-contents");
@@ -160,7 +162,7 @@ export default function Data({ shx }) {
  	const elts = [];
 	for (const i in shxResult.bundles) {
 	  elts.push(<MenuItem key={i} value={i}>
-				  {shxResult.bundles[i].organized.label}
+				  {shxResult.bundles[i].organized.typeInfo.label}
 				</MenuItem>);
 	}
 	

--- a/src/ImmunizationHistory.js
+++ b/src/ImmunizationHistory.js
@@ -60,6 +60,9 @@ function renderImmunizationGroup(
     }
   };
   const renderPerformers = (performers) => {
+
+	if (!performers) return(undefined);
+	
     return (
       <ul>
         {performers.map((p, index) => (

--- a/src/PatientSummary.module.css
+++ b/src/PatientSummary.module.css
@@ -59,5 +59,4 @@
 
 .patCell {
 	font-weight: bold;
-	color: red;
 }

--- a/src/WrongPatientWarning.js
+++ b/src/WrongPatientWarning.js
@@ -57,7 +57,7 @@ export default function WrongPatientWarning({ organized }) {
   return(
 	<div class={styles.warning}>
 	  Warning: It appears that the subject referenced in the information
-	  below may differ from the patient currently selected in the
+	  below may differ from the patient selected in the 
 	  EHR (<span className={styles.deets}>{getPatientDeets()}</span>).
 	  Please ensure a match before proceeding.
 	</div>

--- a/src/WrongPatientWarning.js
+++ b/src/WrongPatientWarning.js
@@ -1,0 +1,66 @@
+import { useState, useEffect } from 'react';
+import { useOptionalFhir } from './OptionalFhir';
+import * as futil from "./lib/fhirUtil.js";
+
+import styles from './WrongPatientWarning.module.css';
+
+export default function WrongPatientWarning({ organized }) {
+
+  const [patient, setPatient] = useState(undefined);
+  const fhir = useOptionalFhir();
+
+  useEffect(() => {
+	
+	try {
+	  if (fhir) fhir.patient.read().then((p) => setPatient(p));
+	}
+	catch (err) {
+	  console.err(err.toString());
+	}
+	
+  });
+
+  const getPatientDeets = () => {
+
+	let deets = "";
+	
+	if (patient.name && patient.name.length > 0) {
+	  deets = "family name " + patient.name[0].family;
+	}
+
+	if (patient.birthDate) {
+	  const dobStr = "DOB " + futil.renderDate(patient.birthDate);
+	  deets = futil.delimiterAppend(deets, dobStr, ", ");
+	}
+
+	return(deets);
+  }
+  
+  // +-------------+
+  // | Main Render |
+  // +-------------+
+  
+  if (!patient) return(undefined);
+  
+  const subjects = organized.typeInfo.subjects;
+  let foundMatch = false;
+		
+  for (const i in subjects) {
+	if (futil.seemsLikeSamePatient(patient, subjects[i])) {
+	  foundMatch = true;
+	  break;
+	}
+  }
+
+  if (foundMatch) return(undefined);
+
+  return(
+	<div class={styles.warning}>
+	  Warning: It appears that the subject referenced in the information
+	  below may differ from the patient currently selected in the
+	  EHR (<span className={styles.deets}>{getPatientDeets()}</span>).
+	  Please ensure a match before proceeding.
+	</div>
+  );
+}
+

--- a/src/WrongPatientWarning.module.css
+++ b/src/WrongPatientWarning.module.css
@@ -1,0 +1,15 @@
+
+.warning {
+	margin-top: 8px;
+	border: 1px solid grey;
+	background-color: lightgray;
+	padding: 8px 8px 8px 8px;
+	max-width: 640px;
+	color: red;
+	font-weight: bold;
+	font-style: italic;
+}
+
+.deets {
+	color: black;
+}


### PR DESCRIPTION
This feature is only relevant when the app is running in an EHR context. Each display type has a bit of code in resources.js that figures out the "subject" of the information (e.g., for an IPS it's Composition[0].subject.reference). If this subject does not match the currently-selected EHR patient (by a loose match using family name and dob) a warning is displayed above the content.

The idea here is to provide a measure of patient safety --- we don't want a provider to act on data from the wrong patient, so we use context when it's available to try to avoid that outcome. Woot!