### PR TITLE
Switch camera

### DIFF
--- a/public/captureQR.html
+++ b/public/captureQR.html
@@ -4,11 +4,15 @@
 
     <title>SHC Reader Capture Window</title>
     <script src='qr-scanner.umd.min.js'></script>
+	<script src="switchCamera.js"></script>
 
   </head>
   <body>
 
 	<video id='video' style='width: 400px; height: 225px;'></video>
+	<div id='switchCamera' style='display: none; margin-top: 8px;'>
+	  <button onclick='sc.switchCameraClick()'>Switch Camera</button>
+	</div>
   
     <script>
 
@@ -16,18 +20,23 @@
 		window.opener.openCameraResult(result.data);
 		window.close();
 	  }
+
+	  const hash = window.location.hash;
+	  const defaultMode = (hash ? hash.substring(1) : 'environment');
 	  
 	  const qrScanner = new QrScanner(
 		document.getElementById('video'),
 		handleQR,
 		{
-		  preferredCamera: 'user',
+		  preferredCamera: sc.getSelectedCamera(defaultMode),
 		  highlightScanRegion: true,
 		  highlightCodeOutline: true,
 		  returnDetailedScanResult: true
 		});
 
-	  qrScanner.start();
+	  qrScanner.start().then(() => {
+		sc.maybeShowSwitchCamera(qrScanner, 'switchCamera');
+	  });
 	  
     </script>
 

--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="Web site created using create-react-app" />
+	<script type="text/javascript" src="%PUBLIC_URL%/switchCamera.js"></script>
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/public/switchCamera.js
+++ b/public/switchCamera.js
@@ -1,0 +1,135 @@
+
+// +--------------------------+
+// | sc.maybeShowSwitchCamera |
+// +--------------------------+
+
+async function maybeShowSwitchCamera(qrScanner, divId) {
+
+  const camIds = await listCameraIds();
+  if (camIds.length === 1) return;
+
+  window.sc._scanner = qrScanner;
+  document.getElementById(divId).style.display = 'block';
+}
+
+// +--------------------+
+// | getSelectedCamera  |
+// | saveSelectedCamera |
+// +--------------------+
+
+function getSelectedCamera(defaultIdMode) {
+  const cached = localStorage.getItem('cameraIdMode');
+  return(cached || defaultIdMode);
+}
+
+function saveSelectedCamera(cameraIdMode) {
+  try { localStorage.setItem('cameraIdMode', cameraIdMode); }
+  catch (err) { console.error(err.toString()); }
+}
+
+// +---------------------------+
+// | switchCameraClick         |
+// | switchCameraClickInternal |
+// +---------------------------+
+
+// deal with double-clickness and defer actual work to switchCameraAction
+
+let switchTimer = undefined;
+const dblClickMillis = 250;
+
+async function switchCameraClick() {
+  switchCameraClickInternal(false);
+}
+
+async function switchCameraClickInternal(isTimer) {
+
+  if (isTimer) {
+	// double-click timeout --- single
+	switchTimer = undefined;
+	await switchCameraAction(false);
+  }
+  else if (switchTimer) {
+	// second click within period --- double
+	clearTimeout(switchTimer);
+	switchTimer = undefined;
+	await switchCameraAction(true);
+  }
+  else {
+	// first click --- set timer
+	switchTimer = setTimeout(() => {
+	  switchCameraClickInternal(true);
+	}, dblClickMillis);
+  }
+}
+
+// +-------------------+
+// | switchCamerAction |
+// +-------------------+
+
+async function switchCameraAction(isDouble) {
+  
+  let currentCam = getSelectedCamera();
+  let newCam = undefined;
+
+  if (isDouble) {
+	// switch by id
+	if (isFacingMode(currentCam)) currentCam = findCurrentCam(true);
+	newCam = await findNextCameraId(currentCam);
+  }
+  else {
+	// switch by mode
+	if (!isFacingMode(currentCam)) currentCam = findCurrentCam(false);
+	newCam = (currentCam === 'user' ? 'environment' : 'user');
+  }
+
+  console.log(`Switching camera from ${currentCam} to ${newCam}`);
+  
+  saveSelectedCamera(newCam);
+  window.sc._scanner.setCamera(newCam);
+}
+
+// +---------+
+// | Helpers |
+// +---------+
+
+async function listCameraIds() {
+
+  const devs = await navigator.mediaDevices.enumerateDevices();
+  return(devs.filter((d) => (d.kind === 'videoinput')).map((c,i) => c.deviceId));
+}
+
+function findCurrentCam(getId) {
+
+  const vid = document.getElementById('video');
+  const track = vid.srcObject.getTracks().find(t => t.kind === 'video');
+  const settings = track.getSettings();
+  return(getId ? settings.deviceId : settings.facingMode);
+}
+
+async function findNextCameraId(currentId) {
+
+  const camIds = await listCameraIds();
+
+  let i = 0;
+  while (i < camIds.length) {
+	if (camIds[i] === currentId) break;
+	++i;
+  }
+
+  return(camIds[(i >= (camIds.length - 1)) ? 0 : i + 1]);
+}
+
+function isFacingMode(s) {
+  return(s === 'user' || s === 'environment');
+}
+
+// +-----------+
+// | "Exports" |
+// +-----------+
+
+window.sc = {
+  'maybeShowSwitchCamera': maybeShowSwitchCamera,
+  'getSelectedCamera': getSelectedCamera,
+  'switchCameraClick': switchCameraClick
+};
+

--- a/src/Photo.js
+++ b/src/Photo.js
@@ -9,8 +9,9 @@ export default function Photo({ viewData }) {
   const [paused, setPaused] = useState(false);
 
   const openCameraClick = () => {
+	const url = 'captureQR.html#' + escape(getSelectedCamera());
 	window.openCameraResult = openCameraResult;
-	window.open('captureQR.html', 'captureQR', 'width=500,height=300');
+	window.open(url, 'captureQR', 'width=500,height=300');
   }
 
   const unPauseCameraClick = () => { setPaused(false); }
@@ -22,6 +23,99 @@ export default function Photo({ viewData }) {
 	viewData(shx);
   }
 
+  // +---------------+
+  // | Switch Camera |
+  // +---------------+
+
+  const maybeShowSwitchCamera = async (qrScanner) => {
+
+	const cams = await QrScanner.listCameras();
+	if (cams.length === 1) return;
+
+	document.getElementById('switchCamera').style.display = 'block';
+  }
+
+  let switchTimer = undefined;
+  const dblClickMillis = 250;
+  
+  const switchCameraClick = async (isTimer) => {
+
+	if (isTimer) {
+	  // double-click timeout --- single
+	  switchTimer = undefined;
+	  await switchCameraAction(false);
+	}
+	else if (switchTimer) {
+	  // second click within period --- double
+	  clearTimeout(switchTimer);
+	  switchTimer = undefined;
+	  await switchCameraAction(true);
+	}
+	else {
+	  // first click --- set timer
+	  switchTimer = setTimeout(() => switchCameraClick(true), dblClickMillis);
+	}
+  }
+
+  const switchCameraAction = async (isDouble) => {
+	
+	let currentCam = getSelectedCamera();
+	let newCam = undefined;
+
+	if (isDouble) {
+	  // switch by id
+	  if (isFacingMode(currentCam)) currentCam = findCurrentCam(true);
+	  newCam = await findNextCameraId(currentCam);
+	}
+	else {
+	  // switch by mode
+	  if (!isFacingMode(currentCam)) currentCam = findCurrentCam(false);
+	  newCam = (currentCam === 'user' ? 'environment' : 'user');
+	}
+
+	console.log(`Switching camera from ${currentCam} to ${newCam}`);
+	
+	saveSelectedCamera(newCam);
+	window.scanner.setCamera(newCam);
+  }
+
+  const findCurrentCam = (getId) => {
+
+	const vid = document.getElementById('video');
+	const track = vid.srcObject.getTracks().find(t => t.kind === 'video');
+	const settings = track.getSettings();
+	return(getId ? settings.deviceId : settings.facingMode);
+  }
+
+  const findNextCameraId = async (currentId) => {
+
+	const cams = await QrScanner.listCameras(true);
+
+	let i = 0;
+	while (i < cams.length) {
+	  if (cams[i].id === currentId) break;
+	  ++i;
+	}
+
+	return(cams[(i >= (cams.length - 1)) ? 0 : i + 1].id);
+  }
+
+  const isFacingMode = (s) => (s === 'user' || s === 'environment');
+
+  function getSelectedCamera() {
+	const cached = localStorage.getItem('cameraIdMode');
+	return(cached || config('cameraIdMode'));
+  }
+
+  function saveSelectedCamera(cameraIdMode) {
+	try { localStorage.setItem('cameraIdMode', cameraIdMode); }
+	catch (err) { console.error(err.toString()); }
+  }
+
+  // +-----------+
+  // | useEffect |
+  // +-----------+
+
   useEffect(() => {
 
 	if (!haveCamera || paused) return;
@@ -30,13 +124,17 @@ export default function Photo({ viewData }) {
 	  document.getElementById('video'),
 	  result => viewData(result.data), 
 	  {
-		preferredCamera: 'user',
+		preferredCamera: getSelectedCamera(),
 		highlightScanRegion: true,
 		highlightCodeOutline: true,
 		returnDetailedScanResult: true
 	  });
 
-	qrScanner.start().catch((err) => {
+	qrScanner.start().then(() => {
+	  window.scanner = qrScanner;
+	  maybeShowSwitchCamera();
+	})
+	.catch((err) => {
 	  console.error(err);
 	  setHaveCamera(false);
 	});
@@ -48,10 +146,15 @@ export default function Photo({ viewData }) {
 	  clearTimeout(timerId);
 	  qrScanner.stop();
 	  qrScanner.destroy();
+	  window.scanner = undefined;
 	}
 	
   }, [haveCamera, setHaveCamera, paused, viewData]);
 	
+  // +--------+
+  // | render |
+  // +--------+
+
   return (
 	<div>
 
@@ -64,8 +167,16 @@ export default function Photo({ viewData }) {
 		</div> }
 
 	  { haveCamera &&
-		<video id='video' style={{ width: '400px', height: '225px' }}></video> }
-	  
+		<>
+		  <video id='video' style={{ width: '400px', height: '225px' }}></video>
+		  <div id='switchCamera' style={{ display: 'none' }}>
+			<Button variant='text' onClick={() => switchCameraClick(false) }>
+			  Change Camera
+			</Button> 
+		  </div>
+		</>
+	  }
+
 	  { !haveCamera &&
 		<Button variant='contained' onClick={openCameraClick}>Open Camera</Button> }
 	  

--- a/src/Photo.js
+++ b/src/Photo.js
@@ -9,7 +9,8 @@ export default function Photo({ viewData }) {
   const [paused, setPaused] = useState(false);
 
   const openCameraClick = () => {
-	const url = 'captureQR.html#' + escape(getSelectedCamera());
+	const cameraIdMode = window.sc.getSelectedCamera(config("cameraIdMode"));
+	const url = 'captureQR.html#' + escape(cameraIdMode);
 	window.openCameraResult = openCameraResult;
 	window.open(url, 'captureQR', 'width=500,height=300');
   }
@@ -21,95 +22,6 @@ export default function Photo({ viewData }) {
   // eslint-disable-next-line
   const openCameraResult = (shx) => {
 	viewData(shx);
-  }
-
-  // +---------------+
-  // | Switch Camera |
-  // +---------------+
-
-  const maybeShowSwitchCamera = async (qrScanner) => {
-
-	const cams = await QrScanner.listCameras();
-	if (cams.length === 1) return;
-
-	document.getElementById('switchCamera').style.display = 'block';
-  }
-
-  let switchTimer = undefined;
-  const dblClickMillis = 250;
-  
-  const switchCameraClick = async (isTimer) => {
-
-	if (isTimer) {
-	  // double-click timeout --- single
-	  switchTimer = undefined;
-	  await switchCameraAction(false);
-	}
-	else if (switchTimer) {
-	  // second click within period --- double
-	  clearTimeout(switchTimer);
-	  switchTimer = undefined;
-	  await switchCameraAction(true);
-	}
-	else {
-	  // first click --- set timer
-	  switchTimer = setTimeout(() => switchCameraClick(true), dblClickMillis);
-	}
-  }
-
-  const switchCameraAction = async (isDouble) => {
-	
-	let currentCam = getSelectedCamera();
-	let newCam = undefined;
-
-	if (isDouble) {
-	  // switch by id
-	  if (isFacingMode(currentCam)) currentCam = findCurrentCam(true);
-	  newCam = await findNextCameraId(currentCam);
-	}
-	else {
-	  // switch by mode
-	  if (!isFacingMode(currentCam)) currentCam = findCurrentCam(false);
-	  newCam = (currentCam === 'user' ? 'environment' : 'user');
-	}
-
-	console.log(`Switching camera from ${currentCam} to ${newCam}`);
-	
-	saveSelectedCamera(newCam);
-	window.scanner.setCamera(newCam);
-  }
-
-  const findCurrentCam = (getId) => {
-
-	const vid = document.getElementById('video');
-	const track = vid.srcObject.getTracks().find(t => t.kind === 'video');
-	const settings = track.getSettings();
-	return(getId ? settings.deviceId : settings.facingMode);
-  }
-
-  const findNextCameraId = async (currentId) => {
-
-	const cams = await QrScanner.listCameras(true);
-
-	let i = 0;
-	while (i < cams.length) {
-	  if (cams[i].id === currentId) break;
-	  ++i;
-	}
-
-	return(cams[(i >= (cams.length - 1)) ? 0 : i + 1].id);
-  }
-
-  const isFacingMode = (s) => (s === 'user' || s === 'environment');
-
-  function getSelectedCamera() {
-	const cached = localStorage.getItem('cameraIdMode');
-	return(cached || config('cameraIdMode'));
-  }
-
-  function saveSelectedCamera(cameraIdMode) {
-	try { localStorage.setItem('cameraIdMode', cameraIdMode); }
-	catch (err) { console.error(err.toString()); }
   }
 
   // +-----------+
@@ -124,15 +36,14 @@ export default function Photo({ viewData }) {
 	  document.getElementById('video'),
 	  result => viewData(result.data), 
 	  {
-		preferredCamera: getSelectedCamera(),
+		preferredCamera: window.sc.getSelectedCamera(config("cameraIdMode")),
 		highlightScanRegion: true,
 		highlightCodeOutline: true,
 		returnDetailedScanResult: true
 	  });
 
 	qrScanner.start().then(() => {
-	  window.scanner = qrScanner;
-	  maybeShowSwitchCamera();
+	  window.sc.maybeShowSwitchCamera(qrScanner, 'switchCamera');
 	})
 	.catch((err) => {
 	  console.error(err);
@@ -170,7 +81,7 @@ export default function Photo({ viewData }) {
 		<>
 		  <video id='video' style={{ width: '400px', height: '225px' }}></video>
 		  <div id='switchCamera' style={{ display: 'none' }}>
-			<Button variant='text' onClick={() => switchCameraClick(false) }>
+			<Button variant='text' onClick={ window.sc.switchCameraClick }>
 			  Change Camera
 			</Button> 
 		  </div>

--- a/src/Photo.js
+++ b/src/Photo.js
@@ -57,7 +57,6 @@ export default function Photo({ viewData }) {
 	  clearTimeout(timerId);
 	  qrScanner.stop();
 	  qrScanner.destroy();
-	  window.scanner = undefined;
 	}
 	
   }, [haveCamera, setHaveCamera, paused, viewData]);

--- a/src/lib/defaults.js
+++ b/src/lib/defaults.js
@@ -16,6 +16,9 @@ export const DEFAULT_CONFIG = {
 	'https://raw.githubusercontent.com/seanno/shc-demo-data/main/keystore/directory.json'
   ],
 
+  // default camera mode ('environment' or 'user') or ID
+  "cameraIdMode": 'environment',
+
   // stop camera scanning after this many millis (default 120 seconds).
   // this is to work around what appear to be memory leaks in the
   // camera module

--- a/src/lib/fhirUtil.js
+++ b/src/lib/fhirUtil.js
@@ -687,7 +687,7 @@ export function renderReferenceMap(o, resources, refRenderFuncMap) {
 	return(renderReferenceMapThrow(o, resources, refRenderFuncMap));
   }
   catch (err) {
-	return(<div>{o.display ? o.display : NA}</div>);
+	return(<div>{o && o.display ? o.display : NA}</div>);
   }
 }
 


### PR DESCRIPTION
This PR implements a "switch camera" button for the reader. It is built so that the functionality can work in both src/Photo.js (React) for standalone mode, and public/captureQR.html (plain html) for EHR "popup" mode. Most of the code is in public/switchCamera.js. Behavior should be:

* If the browsing device has only one camera, no button is shown.
* Single-clicking the button should toggle between "user" and "environment" camera modes (front/back).
* Double-clicking the button should cycle through all available cameras on the device.
* Default mode is "environment".
* Camera selection is persisted to LocalStorage once selected.

The single/double-click thing is to try to optimize for the case where people just want to flip the camera (e.g. on mobile) but still support the case where a device has many possible cameras to pick from (e.g., a laptop with a built-in camera and a plug-in USB camera). 