### PR TITLE
expect Organization or Person for author resources

### DIFF
--- a/src/PatientSummary.js
+++ b/src/PatientSummary.js
@@ -27,7 +27,7 @@ export default function PatientSummary({ organized, dcr }) {
   const comp = organized.byType.Composition[0];
   const rmap = organized.byId;
 
-  const authors = comp.author.map((a) => futil.renderPerson(a, rmap));
+  const authors = comp.author.map((a) => futil.renderOrgOrPerson(a, rmap));
   
   return(
     <div className={styles.container}>

--- a/src/lib/fhirUtil.js
+++ b/src/lib/fhirUtil.js
@@ -3,6 +3,7 @@ const NA = "Unknown";
 
 // +--------------------+
 // | renderOrganization |
+// | renderOrgOrPerson  | |
 // +--------------------+
 
 export function renderOrganization(org, resources) {
@@ -11,6 +12,16 @@ export function renderOrganization(org, resources) {
 
 function renderOrganizationResource(org) {
   return(<div>{org.name}</div>);
+}
+
+export function renderOrgOrPerson(oop, resources) {
+
+  const renderMap = {
+	"Organization": renderOrganization,
+	"any": renderPerson
+  };
+
+  return(renderReferenceMap(oop, resources, renderMap));
 }
 
 // +---------------+


### PR DESCRIPTION
Since this is the second time a resource can be either an Organization or Person (first was the payer in Coverage resources), made a common function to handle it and updated authors rendering to use it. 