### PR TITLE
code split pdf reading plus attr typo in WrongPatientWarning

### DIFF
--- a/src/WrongPatientWarning.js
+++ b/src/WrongPatientWarning.js
@@ -55,7 +55,7 @@ export default function WrongPatientWarning({ organized }) {
   if (foundMatch) return(undefined);
 
   return(
-	<div class={styles.warning}>
+	<div className={styles.warning}>
 	  Warning: It appears that the subject referenced in the information
 	  below may differ from the patient selected in the 
 	  EHR (<span className={styles.deets}>{getPatientDeets()}</span>).

--- a/src/lib/getDocSHX.js
+++ b/src/lib/getDocSHX.js
@@ -5,8 +5,6 @@
 // NYI --- reuse canvas and engine for perf
 
 import QrScanner from 'qr-scanner';
-import * as PdfjsLib from 'pdfjs-dist/build/pdf';
-import PdfjsWorker from 'pdfjs-dist/build/pdf.worker.entry';
 import { b64_to_arr } from './b64.js';
 import { looksLikeSHX } from './SHX.js';
 
@@ -33,6 +31,14 @@ export default async function getDocSHX(fhir, doc) {
 }
 
 async function scanPdf(doc, base64) {
+  
+  const PdfjsLib = await import('pdfjs-dist/build/pdf');
+  const PdfjsWorker = await import('pdfjs-dist/build/pdf.worker.entry');
+
+  return(await _scanPdf(doc, base64, PdfjsLib, PdfjsWorker));
+}
+
+async function _scanPdf(doc, base64, PdfjsLib, PdfjsWorker) {
 
   const canvas = document.createElement('canvas');
   const ctx = canvas.getContext('2d');


### PR DESCRIPTION
This change dynamically loads the pdf library used for searching EHR docs. It reduces the bundle size (a bunch) which is nice for first-run experience for normal users, and skirts a javascript issue that seems to exist in the pdf library on some android chrome builds, for which the ehr stuff isnt relevant anyways.