### PR TITLE
mobile-render-part-2

### DIFF
--- a/src/PatientSummary.js
+++ b/src/PatientSummary.js
@@ -35,7 +35,7 @@ export default function PatientSummary({ organized, dcr }) {
   return (
      <div className={styles.container}>
        <h2>{comp.title}</h2>
-       <div className={styles.dataGrid}>
+       <div className={styles.dataTable}>
          <div className={styles.patientLabel}>Patient</div>
          <div className={styles.patCell}>{futil.renderPerson(comp.subject, rmap)}</div>
 

--- a/src/PatientSummary.js
+++ b/src/PatientSummary.js
@@ -9,44 +9,44 @@ export default function PatientSummary({ organized, dcr }) {
   // | renderSections |
   // +----------------+
 
-  const renderSections = () => {
-	return(comp.section.map((s) => {
-	  return(
-		<tr key={ s.title }>
-		  <th>{ s.title }</th>
-		  <td><PatientSummarySection s={s} rmap={rmap} dcr={dcr} /></td>
-		</tr>
-	  );
-	}));
-  }
+   const renderSections = () => {
+     return comp.section.flatMap((s) => {
+       return [
+         <div key={`${s.title}-title`} className={styles.sectionTitle}>
+           {s.title}
+         </div>,
+         <div key={`${s.title}-content`} className={styles.sectionContent}>
+           <PatientSummarySection s={s} rmap={rmap} dcr={dcr} />
+         </div>
+       ];
+     });
+   }
+
 
   // +-------------+
   // | Main Render |
   // +-------------+
-  
+
   const comp = organized.byType.Composition[0];
   const rmap = organized.byId;
 
   const authors = comp.author.map((a) => futil.renderOrgOrPerson(a, rmap));
-  
-  return(
-    <div className={styles.container}>
-	  <h2>{comp.title}</h2>
-	  <table className={styles.dataTable}>
-		<tbody>
-		  <tr>
-			<th>Patient</th>
-			<td className={styles.patCell}>{ futil.renderPerson(comp.subject, rmap) }</td>
-		  </tr>
-		  <tr>
-			<th>Summary prepared by</th>
-			<td>{ authors }</td>
-		  </tr>
-		  { renderSections() }
-		</tbody>
-	  </table>
-	</div>
+
+  return (
+     <div className={styles.container}>
+       <h2>{comp.title}</h2>
+       <div className={styles.dataGrid}>
+         <div className={styles.patientLabel}>Patient</div>
+         <div className={styles.patCell}>{futil.renderPerson(comp.subject, rmap)}</div>
+
+         <div className={styles.authorLabel}>Summary prepared by</div>
+         <div>{authors}</div>
+
+         {renderSections()}
+       </div>
+     </div>
   );
+
 
 }
 

--- a/src/PatientSummary.js
+++ b/src/PatientSummary.js
@@ -9,18 +9,18 @@ export default function PatientSummary({ organized, dcr }) {
   // | renderSections |
   // +----------------+
 
-   const renderSections = () => {
-     return comp.section.flatMap((s) => {
-       return [
-         <div key={`${s.title}-title`} className={styles.sectionTitle}>
-           {s.title}
-         </div>,
-         <div key={`${s.title}-content`} className={styles.sectionContent}>
-           <PatientSummarySection s={s} rmap={rmap} dcr={dcr} />
-         </div>
-       ];
-     });
-   }
+  const renderSections = () => {
+    return comp.section.flatMap((s) => {
+      return [
+        <div key={`${s.title}-title`} className={styles.sectionTitle}>
+          {s.title}
+        </div>,
+        <div key={`${s.title}-content`} className={styles.sectionContent}>
+          <PatientSummarySection s={s} rmap={rmap} dcr={dcr} />
+        </div>
+      ];
+    });
+  }
 
 
   // +-------------+

--- a/src/PatientSummary.js
+++ b/src/PatientSummary.js
@@ -46,8 +46,6 @@ export default function PatientSummary({ organized, dcr }) {
        </div>
      </div>
   );
-
-
 }
 
 

--- a/src/PatientSummary.module.css
+++ b/src/PatientSummary.module.css
@@ -1,81 +1,94 @@
 
 .container {
-	margin-top: 12px;
+    margin-left: 0;
+    margin-top: 12px;
 }
 
-.dataTable {
-	margin-top: 24px;
-	margin-bottom: 24px;
-	border-collapse: collapse;
-	overflow-x: auto;
+.dataGrid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1px;
+    border: 1px solid #e0e0e0;
 }
 
-.dataTable th, .dataTable td {
-	vertical-align: top;
-	border: 1px solid black;
-	padding: 8px 8px 8px 8px;
-	font-size: smaller;
+.dataGrid > * {
+    padding: 8px;
+    font-size: smaller;
+    border: 1px solid #e0e0e0;
 }
 
-.fhirTable {
-	border-collapse: collapse;
-	width: 100%;
-    border: 1px solid #e0e0e0;  /* Border around the entire table */
-}
-
-.fhirTable td, .fhirTable th {
-	text-align: left;
-	vertical-align: middle;
-	padding: 2px 8px 2px 2px;
-	font-size: 100%;
-	border-right: none;
-	border-bottom: none;
-    border-top: 1px solid #e0e0e0;  /* Enhanced row borders */
-    border-left: 1px solid #e0e0e0;  /* Vertical borders between columns */
-}
-
-.fhirTable th {
-	color: gray;
-    background-color: #f7f7f7;  /* Slightly darker background for headers */
-    border-bottom: 2px solid #d0d0d0;  /* Slightly thicker bottom border for headers */
-}
-
-.fhirTable td {
-	border-top: 1px solid lightgray;
-}
-
-.narrative {
-	background-color: whitesmoke;
-	padding: 8px 8px 8px 8px;
-}
-
-.narrative table {
-	border-collapse: collapse;
-	width: 100%;
-}
-
-.narrative th, .narrative td {
-	padding: 4px 4px 4px 4px;
-	font-size: unset;
-}
-
-.patCell {
-	font-weight: bold;
+.dataGrid > :nth-child(odd) {
+    background-color: #f5f5f5;
+    font-weight: bold;
 }
 
 @media only screen and (max-width: 600px) {
-    .dataTable th, .dataTable td {
-        padding: 2px; /* Reduced padding for smaller screens */
-        font-size: x-small; /* Smaller font size for better visibility on mobile */
+    .dataGrid > * {
+        padding: 2px;
+        font-size: x-small;
+    }
+
+    .dataGrid {
+        grid-template-columns: 1fr;
     }
 }
 
-/* Remove left border for the first column to avoid double borders */
+.fhirTable {
+    border-collapse: collapse;
+    width: 100%;
+    border: 1px solid #e0e0e0;
+}
+
+.fhirTable td, .fhirTable th {
+    text-align: left;
+    vertical-align: middle;
+    padding: 2px 8px 2px 2px;
+    font-size: 100%;
+    border-right: none;
+    border-bottom: none;
+    border-top: 1px solid #e0e0e0;
+    border-left: 1px solid #e0e0e0;
+}
+
+.fhirTable th {
+    color: gray;
+    background-color: #f7f7f7;
+    border-bottom: 2px solid #d0d0d0;
+}
+
+.fhirTable td {
+    border-top: 1px solid lightgray;
+}
+
 .fhirTable tr td:first-child, .fhirTable tr th:first-child {
     border-left: none;
 }
 
-/* Additions for every other column background color */
 .fhirTable tr td:nth-child(even), .fhirTable tr th:nth-child(even) {
     background-color: #f5f5f5;
+}
+
+.narrative {
+    background-color: whitesmoke;
+    padding: 8px;
+}
+
+.narrative table {
+    border-collapse: collapse;
+    width: 100%;
+}
+
+.narrative th, .narrative td {
+    padding: 4px;
+    font-size: unset;
+    border: 1px solid lightgray;
+}
+
+.narrative th {
+    background-color: #f7f7f7;
+    border-bottom: 2px solid #d0d0d0;
+}
+
+.patCell {
+    font-weight: bold;
 }

--- a/src/PatientSummary.module.css
+++ b/src/PatientSummary.module.css
@@ -24,7 +24,6 @@
 
 @media only screen and (max-width: 600px) {
     .dataTable > * {
-        padding: 2px;
         font-size: x-small;
     }
 

--- a/src/PatientSummary.module.css
+++ b/src/PatientSummary.module.css
@@ -4,31 +4,31 @@
     margin-top: 12px;
 }
 
-.dataGrid {
+.dataTable {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
     gap: 1px;
     border: 1px solid #e0e0e0;
 }
 
-.dataGrid > * {
+.dataTable > * {
     padding: 8px;
     font-size: smaller;
     border: 1px solid #e0e0e0;
 }
 
-.dataGrid > :nth-child(odd) {
+.dataTable > :nth-child(odd) {
     background-color: #f5f5f5;
     font-weight: bold;
 }
 
 @media only screen and (max-width: 600px) {
-    .dataGrid > * {
+    .dataTable > * {
         padding: 2px;
         font-size: x-small;
     }
 
-    .dataGrid {
+    .dataTable {
         grid-template-columns: 1fr;
     }
 }


### PR DESCRIPTION
Made one more tweak here per Yuri's recommendation. I transitioned from a table structure to a grid layout for enhancing the mobile view - tried to take up less space with Record Header column. Testing has looked great on the device so far! 
<img width="343" alt="Screenshot 2023-10-10 at 1 29 48 PM" src="https://github.com/the-commons-project/shc-web-reader/assets/38390406/feef26a5-1a07-4374-baf4-f45c365b68aa">
