### PR TITLE
Avoid-browser-from-saving-passcode

### DIFF
--- a/src/Data.js
+++ b/src/Data.js
@@ -37,6 +37,10 @@ export default function Data({ shx }) {
   const passcodeKeyDown = (evt) => {
 	if (evt.key === 'Enter') passcodeClick(); 
   }
+
+  const handleFocus = (evt) => {
+    event.target.removeAttribute('readOnly');
+  }
   
   const renderNeedPasscode = () => {
 
@@ -53,6 +57,7 @@ export default function Data({ shx }) {
 					 margin='normal'
 					 type='password'
 					 autoComplete='off'
+                     onFocus={handleFocus}
 					 autoFocus
 					 inputRef={passcodeRef}
 					 onKeyDown={passcodeKeyDown}


### PR DESCRIPTION
Currently the viewer when opened on a mobile device will try to 

1. save the entered passcode
2. use a stored passcode
3. it tries to update an existing passcode

These behaviors should be avoided on mobile device for passcode protectedSHLs


Note I wasn't able to validate that this works locally as the browsers don't request to save the passcode when working from a localhost so we will need to test in dev to verify. 