### PR TITLE
fixups

### DIFF
--- a/src/PatientSummary.js
+++ b/src/PatientSummary.js
@@ -36,10 +36,10 @@ export default function PatientSummary({ organized, dcr }) {
      <div className={styles.container}>
        <h2>{comp.title}</h2>
        <div className={styles.dataTable}>
-         <div className={styles.patientLabel}>Patient</div>
+         <div className={styles.sectionTitle}>Patient</div>
          <div className={styles.patCell}>{futil.renderPerson(comp.subject, rmap)}</div>
 
-         <div className={styles.authorLabel}>Summary prepared by</div>
+         <div className={styles.sectionTitle}>Summary prepared by</div>
          <div>{authors}</div>
 
          {renderSections()}

--- a/src/PatientSummary.module.css
+++ b/src/PatientSummary.module.css
@@ -6,36 +6,33 @@
 
 .dataTable {
     display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 1px;
+    grid-template-columns: max(200px) 1fr;
+	gap: 0px;
     border: 1px solid #e0e0e0;
 }
 
+@media only screen and (max-width: 600px) {
+	.dataTable {
+		display: block;
+	}
+}
+ 
 .dataTable > * {
     padding: 8px;
     font-size: smaller;
     border: 1px solid #e0e0e0;
+	border-collapse: collapse;
 }
 
-.dataTable > :nth-child(odd) {
+.sectionTitle {
     background-color: #f5f5f5;
     font-weight: bold;
 }
 
-@media only screen and (max-width: 600px) {
-    .dataTable > * {
-        font-size: x-small;
-    }
-
-    .dataTable {
-        grid-template-columns: 1fr;
-    }
-}
 
 .fhirTable {
     border-collapse: collapse;
     width: 100%;
-    border: 1px solid #e0e0e0;
 }
 
 .fhirTable td, .fhirTable th {
@@ -43,28 +40,11 @@
     vertical-align: middle;
     padding: 2px 8px 2px 2px;
     font-size: 100%;
-    border-right: none;
-    border-bottom: none;
-    border-top: 1px solid #e0e0e0;
-    border-left: 1px solid #e0e0e0;
-}
-
-.fhirTable th {
-    color: gray;
-    background-color: #f7f7f7;
-    border-bottom: 2px solid #d0d0d0;
-}
-
-.fhirTable td {
     border-top: 1px solid lightgray;
 }
 
-.fhirTable tr td:first-child, .fhirTable tr th:first-child {
-    border-left: none;
-}
-
-.fhirTable tr td:nth-child(even), .fhirTable tr th:nth-child(even) {
-    background-color: #f5f5f5;
+.fhirTable th {
+    border-top: none;
 }
 
 .narrative {
@@ -90,4 +70,20 @@
 
 .patCell {
     font-weight: bold;
+}
+
+.toggleButton {
+	float: right;
+	margin-top: 6px;
+}
+
+@media only screen and (max-width: 600px) {
+	.toggleButton {
+		display: flex;
+		width: 100%;
+		height: 100%;
+		justify-content: right;
+		float: none;
+		margin-top: 0px;
+	}
 }

--- a/src/PatientSummarySection.js
+++ b/src/PatientSummarySection.js
@@ -58,15 +58,16 @@ export default function PatientSummarySection({ s, rmap, dcr }) {
   const renderToggle = () => {
 
 	return(
+	  <div className={styles.toggleButton}>
 	  <Button
 		data-html2canvas-ignore="true"
-		sx={{ float: "right", marginTop: "10px;" }}
 		size="small"
 		onClick={ () => setViewState(viewState === NTOGGLE ? STOGGLE : NTOGGLE) }
 		startIcon={ <RemoveRedEyeOutlinedIcon /> }>
 		Toggle view
 	  </Button>
-	);
+		</div>
+ 	);
   }
 
   // +-----------------+


### PR DESCRIPTION
I think this works? Changed the grid approach so that as we hit the smaller form we turn to "block" instead of changing the grid layout... and reverted some of the selectors to use classes again since that's easier to track than the nth-child ones. Removed the grey, collapsed borders. Had to do some dancing to make the "toggle view" button layout correctly in both mobile/desktop modes but I think it's good now? Please try this on small and large form to sanity check my work! Thank you.