### PR TITLE
error-message-updates

### DIFF
--- a/src/Data.js
+++ b/src/Data.js
@@ -40,9 +40,9 @@ export default function Data({ shx }) {
   
   const renderNeedPasscode = () => {
 
-	const msg = (passcode
-				 ? "Given passcode not valid for this SMART Health Link."
-				 : "This SMART Health Link requires a passcode.");
+    const msg = (passcode
+                ? shxResult.reasons[0]  // Display the specific error message from PasscodeError
+                : "This SMART Health Link requires a passcode.");
 	
 	return(
 	  <>
@@ -75,7 +75,9 @@ export default function Data({ shx }) {
   // +-------------+
 
   const renderError = (reasons) => {
-	return(<div>{Array.isArray(reasons) ? reasons.join('; ') : reasons}</div>);
+       let displayReasons = Array.isArray(reasons) ? reasons : [reasons];
+       displayReasons = displayReasons.map(reason => reason.replace(/^Error: /, ''));
+       return(<div>{displayReasons.join('; ')}</div>);
   }
 
   // +---------------------+

--- a/src/lib/SHX.js
+++ b/src/lib/SHX.js
@@ -324,7 +324,14 @@ async function fetchSHLManifest(shlPayload, passcode) {
   });
 
   if (response.status === 401 && passcode) {
-	throw new PasscodeError("Passcode incorrect.");
+    const responseBody = await response.json();
+    const remainingAttempts = responseBody.remainingAttempts;
+    const attemptText = remainingAttempts === 1 ? "attempt" : "attempts";
+    throw new PasscodeError(`Passcode incorrect. ${remainingAttempts} ${attemptText} remaining.`);
+  }
+
+  if (response.status === 404) {
+    throw new Error("The SHL is no longer active.");
   }
 
   if (response.status !== 200) {


### PR DESCRIPTION
hey @seanno, Patrick pointed out that the error messaging for the passcode logic needed to be updated. I made some minor changes to follow to SHL spec.

For 401 now showing: Passcode incorrect. (#) attempts remaining.
For 404: The SHL is no longer active.

Background information: 

When a user enters an invalid passcode more than 3 times the reader just shows Error:Manifest: 404 Instead of the actual message returned which is The SHL passcode has been incorrectly entered more than 3 times. The SMART Health Link has been disabled.

The actual number will vary from platform to platform. This is from the spec:

If the SHLink is no longer active, the Resource Server SHALL respond with a 404.

If an invalid Passcode is supplied, the Resource Server SHALL reject the request and SHALL enforce a total lifetime count of incorrect Passcodes for a given SHLink, to prevent attackers from performing an exhaustive Passcode search. The error response for an invalid Passcode SHALL use the 401 HTTP status code and the response body SHALL be a JSON payload with remainingAttempts: number of attempts remaining before the SHL is disabled
