### PR TITLE
diagnostic for UUtah IPS

### DIFF
--- a/src/lib/fhirUtil.js
+++ b/src/lib/fhirUtil.js
@@ -720,6 +720,7 @@ export function renderReferenceMapThrow(o, resources, refRenderFuncMap) {
 // +------------------+
 
 export function resolveReference(o, resources) {
+  if (!o) { console.trace("!!! resolveReference"); return(undefined); }
   if (o.resourceType) return(o);
   if (o.reference && o.reference in resources) return(resources[o.reference]);
   return(undefined);


### PR DESCRIPTION
Have seen at least one real-world IPS (from University of Utah) that dies with a null object in resolveReference. Catching that and returning undefined upstream, but also emitting a console trace because this is potentially a problem (don't want to skip rendering an important element) --- will use this data to try for a more targeted fix.