### PR TITLE
IPS with only fullUrl in entry array item

### DIFF
--- a/src/lib/resources.js
+++ b/src/lib/resources.js
@@ -60,10 +60,15 @@ export function organizeResources(bundle, labelCounters) {
 
   if (bundle.contentOK() && bundle.fhir.entry) {
 	for (const i in bundle.fhir.entry) {
-	  
-	  const e = bundle.fhir.entry[i];
-	  const r = e.resource;
 
+	  const e = bundle.fhir.entry[i];
+
+	  if (!e.resource) {
+		console.error("Malformed bundle entry: " + JSON.stringify(e, null, 2));
+		continue;
+	  }
+	  
+	  const r = e.resource;
 	  organized.all.push(r);
 	  
 	  organized.byId[e.fullUrl] = r;


### PR DESCRIPTION
encountered IPS with an almost-empty element in the entry array --- no resource as required by spec. Detect and skip it, outputting the malformed content to console for future debugging purposes.