### PR TITLE
Paste link rename

### DIFF
--- a/src/About.js
+++ b/src/About.js
@@ -43,7 +43,6 @@ export default function About({ setTab, tabValues }) {
 	  <div className={styles.content} >
 		<h1>{t('aboutSubtitle')}</h1>
 
-		{ config("showScan") && renderTabButton(tabValues.Scan, t('scanDescriptionShort')) }
 		{ config("showPhoto") && renderTabButton(tabValues.Photo, t('photoDescriptionShort')) }
 		{ config("showFile") && renderTabButton(tabValues.File, t('openFileText')) }
 		{ config("showScan") && renderTabButton(tabValues.Scan, t('typeOrPaste')) }

--- a/src/lib/languages.js
+++ b/src/lib/languages.js
@@ -105,8 +105,8 @@ export const languages = {
     // Scan.js
     scanError: 'Error scanning QR code. Please try again.',
     scanSuccess: 'QR code scanned successfully',
-    readCode: 'Read Code',
-    scanTitle: 'Scan a Smart Health Card QR Code',
+    readCode: 'Open Link',
+    scanTitle: 'Paste a SMART Health Link',
     // Buttons
     saveToPDF: 'Save to PDF',
     saveToFHIR: 'Save to FHIR',
@@ -317,8 +317,8 @@ export const languages = {
     // Scan.js
     scanError: 'Erreur lors du scan du code QR. Veuillez réessayer.',
     scanSuccess: 'Code QR scanné avec succès',
-    readCode: 'Lire le code',
-    scanTitle: 'Numériser un code QR de santé Smart',
+    readCode: 'Ouvrir le lien',
+    scanTitle: 'Coller un lien SMART Health',
 
     // Buttons
     saveToPDF: 'Sauvegarder au Format PDF',

--- a/src/lib/languages.js
+++ b/src/lib/languages.js
@@ -2,7 +2,7 @@ export const languages = {
   en: {
     // App.js
     aboutTab: 'About',
-    scanTab: 'Scan Card',
+    scanTab: 'Paste Link',
     fileTab: 'Open file',
     photoTab: 'Use your camera',
     searchTab: 'Search Record',
@@ -12,7 +12,6 @@ export const languages = {
     aboutTitle: 'SMART Health Card Viewer',
     aboutSubtitle: 'View SMART Health Cards',
     getStarted: 'Get Started',
-    scanDescriptionShort: 'Use a 2D barcode scanner',
     photoDescriptionShort: 'Start scanning using your camera',
     fileDescriptionShort: 'Upload a file containing a SMART Health Card',
 
@@ -114,7 +113,7 @@ export const languages = {
     source: 'Source',
     takePhotoText: 'Scan',
     openFileText: 'Open file',
-    typeOrPaste: 'Type or paste a code',
+    typeOrPaste: 'Paste Link',
     findCode: 'Find a code in patient record',
 
     // TCPFooter.js
@@ -214,7 +213,7 @@ export const languages = {
   fr: {
     // App.js
     aboutTab: 'À propos',
-    scanTab: 'Numériser une carte',
+    scanTab: 'Coller le lien',
     fileTab: 'Ouvrir un fichier',
     photoTab: 'Utiliser votre caméra',
     searchTab: 'Rechercher un dossier',
@@ -224,7 +223,6 @@ export const languages = {
     aboutTitle: 'Lecteur de carte de santé SMART',
     aboutSubtitle: 'Lit et vérifie les cartes de santé SMART',
     getStarted: 'Débuter',
-    scanDescriptionShort: 'Utiliser un lecteur de codes-barres 2D',
     photoDescriptionShort: 'Commencer à numériser en utilisant votre caméra',
     fileDescriptionShort:  "Le lecteur peut généralement lire les fichiers portant l'extension .smart-health-card ou .fhir.",
 
@@ -329,7 +327,7 @@ export const languages = {
     startScanningText: 'Commencer à numériser',
     takePhotoText: 'Numériser',
     openFileText: 'Ouvrir un fichier',
-    typeOrPaste: 'Saisir ou coller un code',
+    typeOrPaste: 'Coller le lien',
     findCode: 'Rechercher un code dans le dossier patient',
 
     // TCPFooter.js


### PR DESCRIPTION
## Summary

Renames the user-facing entry point for pasting SMART Health links. The
"Scan Card" terminology was misleading since this flow doesn't actually
scan anything — it accepts a pasted link.

### Changes
- Top-nav tab: **Scan Card → Paste Link** (`scanTab` string)
- About page button: **Type or paste a code → Paste Link** (`typeOrPaste` string)
- About page button removed: **Use a 2D barcode scanner** (the `scanDescriptionShort` entry button — its translation strings were also removed since they're no longer referenced)
- Scan page heading: **Scan a Smart Health Card QR Code → Paste a SMART Health Link** (`scanTitle` string)
- Scan page submit button: **Read Code → Open Link** (`readCode` string)
- French translations updated for all of the above

No behavior changes, no config changes — purely UI text and one removed redundant button.