### PR TITLE
Enable Scan Card tab on commonhealth.org production

### DIFF
--- a/src/lib/defaults.js
+++ b/src/lib/defaults.js
@@ -45,7 +45,7 @@ export const DOMAIN_OVERRIDES = {
   // TCP production
   "commonhealth.org": {
 	
-	"showScan": false,
+	"showScan": true,
 	"showSearch": false,
 	
 	"trustedDirectories": [


### PR DESCRIPTION
Removes the production override that hid the Scan tab. Default behavior (showScan: true) now applies on commonhealth.org.