### PR TITLE
Reapply "Merge pull request #135 from the-commons-project/paste-link-rename"

### DIFF
--- a/src/About.js
+++ b/src/About.js
@@ -43,7 +43,6 @@ export default function About({ setTab, tabValues }) {
 	  <div className={styles.content} >
 		<h1>{t('aboutSubtitle')}</h1>
 
-		{ config("showScan") && renderTabButton(tabValues.Scan, t('scanDescriptionShort')) }
 		{ config("showPhoto") && renderTabButton(tabValues.Photo, t('photoDescriptionShort')) }
 		{ config("showFile") && renderTabButton(tabValues.File, t('openFileText')) }
 		{ config("showScan") && renderTabButton(tabValues.Scan, t('typeOrPaste')) }

--- a/src/lib/languages.js
+++ b/src/lib/languages.js
@@ -2,7 +2,7 @@ export const languages = {
   en: {
     // App.js
     aboutTab: 'About',
-    scanTab: 'Scan Card',
+    scanTab: 'Paste Link',
     fileTab: 'Open file',
     photoTab: 'Use your camera',
     searchTab: 'Search Record',
@@ -12,7 +12,6 @@ export const languages = {
     aboutTitle: 'SMART Health Card Viewer',
     aboutSubtitle: 'View SMART Health Cards',
     getStarted: 'Get Started',
-    scanDescriptionShort: 'Use a 2D barcode scanner',
     photoDescriptionShort: 'Start scanning using your camera',
     fileDescriptionShort: 'Upload a file containing a SMART Health Card',
 
@@ -106,15 +105,15 @@ export const languages = {
     // Scan.js
     scanError: 'Error scanning QR code. Please try again.',
     scanSuccess: 'QR code scanned successfully',
-    readCode: 'Read Code',
-    scanTitle: 'Scan a Smart Health Card QR Code',
+    readCode: 'Open Link',
+    scanTitle: 'Paste a SMART Health Link',
     // Buttons
     saveToPDF: 'Save to PDF',
     saveToFHIR: 'Save to FHIR',
     source: 'Source',
     takePhotoText: 'Scan',
     openFileText: 'Open file',
-    typeOrPaste: 'Type or paste a code',
+    typeOrPaste: 'Paste Link',
     findCode: 'Find a code in patient record',
 
     // TCPFooter.js
@@ -214,7 +213,7 @@ export const languages = {
   fr: {
     // App.js
     aboutTab: 'À propos',
-    scanTab: 'Numériser une carte',
+    scanTab: 'Coller le lien',
     fileTab: 'Ouvrir un fichier',
     photoTab: 'Utiliser votre caméra',
     searchTab: 'Rechercher un dossier',
@@ -224,7 +223,6 @@ export const languages = {
     aboutTitle: 'Lecteur de carte de santé SMART',
     aboutSubtitle: 'Lit et vérifie les cartes de santé SMART',
     getStarted: 'Débuter',
-    scanDescriptionShort: 'Utiliser un lecteur de codes-barres 2D',
     photoDescriptionShort: 'Commencer à numériser en utilisant votre caméra',
     fileDescriptionShort:  "Le lecteur peut généralement lire les fichiers portant l'extension .smart-health-card ou .fhir.",
 
@@ -319,8 +317,8 @@ export const languages = {
     // Scan.js
     scanError: 'Erreur lors du scan du code QR. Veuillez réessayer.',
     scanSuccess: 'Code QR scanné avec succès',
-    readCode: 'Lire le code',
-    scanTitle: 'Numériser un code QR de santé Smart',
+    readCode: 'Ouvrir le lien',
+    scanTitle: 'Coller un lien SMART Health',
 
     // Buttons
     saveToPDF: 'Sauvegarder au Format PDF',
@@ -329,7 +327,7 @@ export const languages = {
     startScanningText: 'Commencer à numériser',
     takePhotoText: 'Numériser',
     openFileText: 'Ouvrir un fichier',
-    typeOrPaste: 'Saisir ou coller un code',
+    typeOrPaste: 'Coller le lien',
     findCode: 'Rechercher un code dans le dossier patient',
 
     // TCPFooter.js


### PR DESCRIPTION
## Summary

Reverts commit `940697b`, which itself reverted PR #135 (paste-link-rename
landing on main by mistake). PR #135's changes are the correct end-state
for main — they were just merged to the wrong base initially. This PR
restores them now that they've been validated on develop via PR #136.

Net effect: brings the "Paste Link" rename, button removal, and Scan
page heading/button updates onto main. Pairs with the just-merged
`enable-paste-link-prod` (PR #137) so production gets both the tab
visibility flip and the new copy.

Without this PR, a normal develop→main merge would skip the rename
commits — git treats them as already in main's history (via the
reverted #135 merge) even though the file content was undone.