### PR TITLE
Drop redundant showScan override on commonhealth.org

### DIFF
--- a/src/lib/defaults.js
+++ b/src/lib/defaults.js
@@ -45,7 +45,6 @@ export const DOMAIN_OVERRIDES = {
   // TCP production
   "commonhealth.org": {
 	
-	"showScan": false,
 	"showSearch": false,
 	
 	"trustedDirectories": [


### PR DESCRIPTION
## Summary

Removes the now-redundant `showScan` override in the `commonhealth.org`
block of `src/lib/defaults.js`. The override matched the default value
of `true`, so it had no effect — pure noise that future devs would
look at and wonder about.

No behavior change anywhere. The `commonhealth.org` block now only
contains overrides that actually differ from defaults.

Pairs with the same change on `main` so the two branches don't
perpetually diff on this single line.

## Test plan

- [x] Confirm the dev viewer still shows the Paste Link tab (default `showScan: true` still wins)
- [x] After the matching PR lands on main and is deployed, confirm viewer.commonhealth.org still shows the Paste Link tab