### PR TITLE
Drop redundant showScan override on commonhealth.org

### DIFF
--- a/src/lib/defaults.js
+++ b/src/lib/defaults.js
@@ -45,7 +45,6 @@ export const DOMAIN_OVERRIDES = {
   // TCP production
   "commonhealth.org": {
 	
-	"showScan": true,
 	"showSearch": false,
 	
 	"trustedDirectories": [


### PR DESCRIPTION
## Summary

Removes the now-redundant `showScan` override in the `commonhealth.org`
block of `src/lib/defaults.js`. The override matches the default value
of `true`, so it has no effect — pure noise that future devs would
look at and wonder about.

No behavior change. The `commonhealth.org` block now only contains
overrides that actually differ from defaults.

Pairs with the same change on `develop` so the two branches don't
perpetually diff on this single line.

## Test plan

- [x] After tagging and deploying to prod (`v-shl…-prod`) and invalidating CloudFront, confirm viewer.commonhealth.org still shows the Paste Link tab (default `showScan: true` now drives the behavior directly)
- [x] Confirm no other production behavior changed